### PR TITLE
Fail safe error fix

### DIFF
--- a/lib/get-doctype.js
+++ b/lib/get-doctype.js
@@ -70,7 +70,7 @@ var parse = function(parseType, whatToParse, callback) {
     } else if (doctypeParts[1] === "SYSTEM") {
       doctype.type = doctypeParts[1];
       delete doctype.pubid;
-    } else if (doctypeParts[1].charAt(0)) {
+    } else if (doctypeParts[1] && doctypeParts[1].charAt(0)) {
       doctype.type = "LOCAL";
       doctype.pubid;
       doctype.sysid;


### PR DESCRIPTION
For when the doctype doesn’t have multiple values.

I used your package to get the doctype from a html document, and since it’s just `<!doctype html>`  now, the script crashed.

I know this is supposed to be used for .xml files but it works great for .html files as well :+1: 
